### PR TITLE
Issues found on tryout

### DIFF
--- a/pbrr/parser.py
+++ b/pbrr/parser.py
@@ -92,8 +92,9 @@ class Parser:
 
         # reorder by most recent first (seen inverse order)
         parsed_entries = sorted(parsed_entries, key=lambda s: (s.published), reverse=True)
-        # correct site last update time with latest entry (some sites report incorrectly or not even have)
-        parsed_site.last_updated = parsed_entries[0].published
+        if parsed_entries:
+            # correct site last update time with latest entry (some sites report incorrectly or not even have)
+            parsed_site.last_updated = parsed_entries[0].published
 
         Log.info("> Fetched: {title}".format(title=title))
 


### PR DESCRIPTION
A sub-set of my OPML that breaks pbbr:
```
<?xml version="1.0" encoding="UTF-8"?>
<opml version="1.0">
<head><title>Test/title></head>
<body>
  <outline type="rss" text="The Sea of Ideas" title="The Sea of Ideas" xmlUrl="http://feeds.feedburner.com/TheSeaOfIdeas" htmlUrl="https://paulbakaus.com"/>
  <outline type="rss" text="Designer News Feed" title="Designer News Feed" xmlUrl="https://news.layervault.com/?format=rss" htmlUrl="https://www.designernews.co/"/>
</body>
</opml>
```


## First entry (IndexError) https://github.com/Kartones/pbrr/commit/a743f6c3da64595fd797099430255dbdaf55281e
```
Traceback (most recent call last):
  File "run.py", line 16, in <module>
    reader.run()
  File "/Users/davidfq/Code/pbrr/pbrr/pbrr.py", line 26, in run
    parsed_data = parser.fetch_site(url=url, title=title, category=category)
  File "/Users/davidfq/Code/pbrr/pbrr/parser.py", line 97, in fetch_site
    parsed_site.last_updated = parsed_entries[0].published
IndexError: list index out of range
```

## Second entry (Timeout)
```
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/urllib/request.py", line 1319, in do_open
    h.request(req.get_method(), req.selector, req.data, headers,
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/http/client.py", line 1230, in request
    self._send_request(method, url, body, headers, encode_chunked)
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/http/client.py", line 1276, in _send_request
    self.endheaders(body, encode_chunked=encode_chunked)
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/http/client.py", line 1225, in endheaders
    self._send_output(message_body, encode_chunked=encode_chunked)
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/http/client.py", line 1004, in _send_output
    self.send(msg)
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/http/client.py", line 944, in send
    self.connect()
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/http/client.py", line 1392, in connect
    super().connect()
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/http/client.py", line 915, in connect
    self.sock = self._create_connection(
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/socket.py", line 808, in create_connection
    raise err
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/socket.py", line 796, in create_connection
    sock.connect(sa)
TimeoutError: [Errno 60] Operation timed out

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/davidfq/Code/pbrr/pbrr/parser.py", line 61, in fetch_site
    source_site = feedparser.parse(
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/site-packages/feedparser/api.py", line 214, in parse
    data = _open_resource(url_file_stream_or_string, etag, modified, agent, referrer, handlers, request_headers, result)
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/site-packages/feedparser/api.py", line 114, in _open_resource
    return http.get(url_file_stream_or_string, etag, modified, agent, referrer, handlers, request_headers, result)
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/site-packages/feedparser/http.py", line 158, in get
    f = opener.open(request)
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/urllib/request.py", line 525, in open
    response = self._open(req, data)
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/urllib/request.py", line 542, in _open
    result = self._call_chain(self.handle_open, protocol, protocol +
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/urllib/request.py", line 502, in _call_chain
    result = func(*args)
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/urllib/request.py", line 1362, in https_open
    return self.do_open(http.client.HTTPSConnection, req,
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/urllib/request.py", line 1322, in do_open
    raise URLError(err)
urllib.error.URLError: <urlopen error [Errno 60] Operation timed out>

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "run.py", line 16, in <module>
    reader.run()
  File "/Users/davidfq/Code/pbrr/pbrr/pbrr.py", line 26, in run
    parsed_data = parser.fetch_site(url=url, title=title, category=category)
  File "/Users/davidfq/Code/pbrr/pbrr/parser.py", line 75, in fetch_site
    ["{}={}".format(key, source_site.headers[key]) for key in source_site.headers.keys()]
UnboundLocalError: local variable 'source_site' referenced before assignment
```

